### PR TITLE
Breakglass alerting for users not in configured group list

### DIFF
--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -7,18 +7,21 @@ import base64
 import logging
 import os
 import time
-
 import boto3
+import okta
+
 from botocore.exceptions import ClientError
 from kmsauth import KMSTokenValidator, TokenValidationError
 from marshmallow.exceptions import ValidationError
-from okta import UsersClient
 from okta.models.user import UserProfile as OktaUserProfile
 
 from bless.config.bless_config import BlessConfig, \
     BLESS_OPTIONS_SECTION, \
     CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, \
     CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
+    CERTIFICATE_BREAKGLASS_BEFORE_SEC_OPTION, \
+    CERTIFICATE_BREAKGLASS_AFTER_SEC_OPTION, \
+    BREAKGLASS_USER_OPTION, \
     ENTROPY_MINIMUM_BITS_OPTION, \
     RANDOM_SEED_BYTES_OPTION, \
     BLESS_CA_SECTION, \
@@ -30,13 +33,15 @@ from bless.config.bless_config import BlessConfig, \
     TEST_USER_OPTION, \
     CERTIFICATE_EXTENSIONS_OPTION, \
     ENCRYPTED_OKTA_API_TOKEN_OPTION, \
-    OKTA_BASE_URL_OPTION
+    OKTA_OPTIONS_SECTION, \
+    OKTA_BASE_URL_OPTION, \
+    OKTA_ALLOWED_GROUPS_OPTION
+
 from bless.request.bless_request import BlessSchema
 from bless.ssh.certificate_authorities.ssh_certificate_authority_factory import \
     get_ssh_certificate_authority
 from bless.ssh.certificates.ssh_certificate_builder import SSHCertificateType
 from bless.ssh.certificates.ssh_certificate_builder_factory import get_ssh_certificate_builder
-
 
 VALID_SSH_RSA_PUBLIC_KEY_HEADER = "ssh-rsa AAAAB3NzaC1yc2"
 
@@ -60,28 +65,43 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
     region = os.environ['AWS_REGION']
 
     # Load the deployment config values
-    config = BlessConfig(region,
-                         config_file=config_file)
+    config = BlessConfig(region, config_file=config_file)
+
+    logger = logging.getLogger(__name__)
 
     logging_level = config.get(BLESS_OPTIONS_SECTION, LOGGING_LEVEL_OPTION)
     numeric_level = getattr(logging, logging_level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: {}'.format(logging_level))
-
-    logger = logging.getLogger()
     logger.setLevel(numeric_level)
 
-    certificate_validity_before_seconds = config.getint(BLESS_OPTIONS_SECTION,
-                                                        CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION)
-    certificate_validity_after_seconds = config.getint(BLESS_OPTIONS_SECTION,
-                                                       CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
+    certificate_validity_before_seconds = config.getint(BLESS_OPTIONS_SECTION, CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION)
+    certificate_validity_after_seconds = config.getint(BLESS_OPTIONS_SECTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
+    certificate_breakglass_validity_before_seconds = config.getint(
+        BLESS_OPTIONS_SECTION,
+        CERTIFICATE_BREAKGLASS_BEFORE_SEC_OPTION
+    )
+    certificate_breakglass_validity_after_seconds = config.getint(
+        BLESS_OPTIONS_SECTION,
+        CERTIFICATE_BREAKGLASS_AFTER_SEC_OPTION
+    )
+
+    breakglass_user = config.get(BLESS_OPTIONS_SECTION, BREAKGLASS_USER_OPTION)
+
     entropy_minimum_bits = config.getint(BLESS_OPTIONS_SECTION, ENTROPY_MINIMUM_BITS_OPTION)
     random_seed_bytes = config.getint(BLESS_OPTIONS_SECTION, RANDOM_SEED_BYTES_OPTION)
     ca_private_key_file = config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
+
     password_ciphertext_b64 = config.getpassword()
+
     certificate_extensions = config.get(BLESS_OPTIONS_SECTION, CERTIFICATE_EXTENSIONS_OPTION)
-    encrypted_okta_api_token = config.get(BLESS_CA_SECTION, ENCRYPTED_OKTA_API_TOKEN_OPTION)
-    okta_base_url = config.get(BLESS_CA_SECTION, OKTA_BASE_URL_OPTION)
+
+    encrypted_okta_api_token = config.get(OKTA_OPTIONS_SECTION, ENCRYPTED_OKTA_API_TOKEN_OPTION)
+    okta_base_url = config.get(OKTA_OPTIONS_SECTION, OKTA_BASE_URL_OPTION)
+    okta_allowed_groups = config.get(OKTA_OPTIONS_SECTION, OKTA_ALLOWED_GROUPS_OPTION)
+    if okta_allowed_groups:
+        okta_allowed_groups = set(okta_allowed_groups.split(','))
+        logger.debug("Allowed okta groups: {}".format(okta_allowed_groups))
 
     # Process cert request
     schema = BlessSchema(strict=True)
@@ -90,19 +110,21 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
     except ValidationError as e:
         return error_response('InputValidationError', str(e))
 
-    logger.info('Bless lambda invoked by [user: {0}, bastion_ips:{1}, public_key: {2}, kmsauth_token:{3}]'.format(
-        request.bastion_user,
-        request.bastion_user_ip,
+    logger.info('Bless lambda invoked by okta user: {}@{}, bastion user: {}, kmsauth_token: {}]'.format(
         request.okta_user,
-        request.kmsauth_token))
+        request.bastion_user_ip,
+        request.bastion_user,
+        request.kmsauth_token)
+    )
 
     # read the private key .pem
     with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
         ca_private_key = f.read()
 
+    kms_client = boto3.client('kms', region_name=region)
+
     # decrypt ca private key password
     if ca_private_key_password is None:
-        kms_client = boto3.client('kms', region_name=region)
         try:
             ca_password = kms_client.decrypt(
                 CiphertextBlob=base64.b64decode(password_ciphertext_b64))
@@ -112,7 +134,6 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
 
     # decrypt okta api token
     if okta_api_token is None:
-        kms_client = boto3.client('kms', region_name=region)
         try:
             decrypted_okta_api_token = kms_client.decrypt(
                 CiphertextBlob=base64.b64decode(encrypted_okta_api_token))
@@ -120,12 +141,36 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
         except ClientError as e:
             return error_response('ClientError', str(e))
 
+    '''
+    Fetch user context from Okta
+    * Username
+    * Groups
+    * SSH key
+    '''
+
     # add extra property to Okta user profile schema
     OktaUserProfile.types['public_key'] = str
 
-    # fetch pubkey from Okta
-    okta_users_client = UsersClient(okta_base_url, okta_api_token)
+    okta_users_client = okta.UsersClient(okta_base_url, okta_api_token)
+
     user = okta_users_client.get_user(request.okta_user)
+    groups_info = okta_users_client.get_user_groups(request.okta_user)
+
+    groups = set()
+    for group_info in groups_info:
+        # Encode unicode response from okta json api as a byte string to ease comparisons
+        groups.add(group_info.profile.name.encode('utf-8'))
+
+    logger.debug('User groups: {}'.format(groups))
+
+    allowed_groups = okta_allowed_groups
+    logger.debug('Whitelist groups: {}'.format(allowed_groups))
+
+    logger.debug('Matched groups: {}'.format(groups.intersection(allowed_groups)))
+
+    # If the len is greater than 0, breakglass will be false.
+    breakglass = not len(groups.intersection(allowed_groups))
+
     public_key_to_sign = user.profile.public_key
     if public_key_to_sign.startswith(VALID_SSH_RSA_PUBLIC_KEY_HEADER):
         pass
@@ -151,17 +196,16 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
     # cert values determined only by lambda and its configs
     current_time = int(time.time())
     test_user = config.get(BLESS_OPTIONS_SECTION, TEST_USER_OPTION)
-    if (test_user and (request.bastion_user == test_user or
-            request.remote_usernames == test_user)):
+    if test_user and (request.bastion_user == test_user or request.remote_usernames == test_user):
         # This is a test call, the lambda will issue an invalid
         # certificate where valid_before < valid_after
         valid_before = current_time
         valid_after = current_time + 1
         bypass_time_validity_check = True
-    else:
+    else:  # Normal user flow
+        bypass_time_validity_check = False
         valid_before = current_time + certificate_validity_after_seconds
         valid_after = current_time - certificate_validity_before_seconds
-        bypass_time_validity_check = False
 
     # Authenticate the user with KMS, if key is setup
     if config.get(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION):
@@ -187,6 +231,17 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
     ca = get_ssh_certificate_authority(ca_private_key, ca_private_key_password)
     cert_builder = get_ssh_certificate_builder(ca, SSHCertificateType.USER,
                                                public_key_to_sign)
+    # Handle breakglass certificate modifications
+    if breakglass:
+        logger.critical('Breakglass access for okta user: {}@{}, bastion user: {}'.format(
+            request.okta_user,
+            request.bastion_user_ip,
+            request.bastion_user)
+        )
+        valid_before = current_time + certificate_breakglass_validity_before_seconds
+        valid_after = current_time - certificate_breakglass_validity_after_seconds
+        cert_builder.add_valid_principal(breakglass_user)
+
     for username in request.remote_usernames.split(','):
         cert_builder.add_valid_principal(username)
 
@@ -201,10 +256,18 @@ def lambda_handler(event, context=None, ca_private_key_password=None, okta_api_t
         cert_builder.clear_extensions()
 
     # cert_builder is needed to obtain the SSH public key's fingerprint
-    key_id = 'request[{}] for[{}] from[{}] command[{}] ssh_key:[{}]  ca:[{}] valid_to[{}]'.format(
-        context.aws_request_id, request.bastion_user, request.bastion_user_ip, request.command,
-        cert_builder.ssh_public_key.fingerprint, context.invoked_function_arn,
-        time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(valid_before)))
+    key_id = 'AWS Request ID: {}, User: {}, Source IP: {}, Command: {}, ' \
+             'Fingerprint: {}, Bless CA: {}, Expires: {}'\
+        .format(
+            context.aws_request_id,
+            request.bastion_user,
+            request.bastion_user_ip,
+            request.command,
+            cert_builder.ssh_public_key.fingerprint,
+            context.invoked_function_arn,
+            time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(valid_before))
+        )
+
     cert_builder.set_critical_option_source_addresses(request.bastion_ips)
     cert_builder.set_key_id(key_id)
     cert = cert_builder.get_cert_file(bypass_time_validity_check)

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -8,7 +8,13 @@ import ConfigParser
 BLESS_OPTIONS_SECTION = 'Bless Options'
 CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION = 'certificate_validity_before_seconds'
 CERTIFICATE_VALIDITY_AFTER_SEC_OPTION = 'certificate_validity_after_seconds'
+CERTIFICATE_BREAKGLASS_BEFORE_SEC_OPTION = 'certificate_breakglass_validity_before_seconds'
+CERTIFICATE_BREAKGLASS_AFTER_SEC_OPTION = 'certificate_breakglass_validity_after_seconds'
 CERTIFICATE_VALIDITY_SEC_DEFAULT = 60 * 2
+CERTIFICATE_BREAKGLASS_SEC_DEFAULT = 60
+
+BREAKGLASS_USER_OPTION = 'breakglass_user'
+BREAKGLASS_USER_DEFAULT = None
 
 ENTROPY_MINIMUM_BITS_OPTION = 'entropy_minimum_bits'
 ENTROPY_MINIMUM_BITS_DEFAULT = 2048
@@ -33,8 +39,17 @@ CERTIFICATE_EXTENSIONS_DEFAULT = 'permit-X11-forwarding,' \
 BLESS_CA_SECTION = 'Bless CA'
 CA_PRIVATE_KEY_FILE_OPTION = 'ca_private_key_file'
 KMS_KEY_ID_OPTION = 'kms_key_id'
+
+OKTA_OPTIONS_SECTION = 'Okta Options'
+
 ENCRYPTED_OKTA_API_TOKEN_OPTION = 'encrypted_okta_api_token'
+ENCRYPTED_OKTA_API_TOKEN_DEFAULT = None
+
 OKTA_BASE_URL_OPTION = 'okta_base_url'
+OKTA_BASE_URL_DEFAULT = None
+
+OKTA_ALLOWED_GROUPS_OPTION = 'okta_allowed_groups'
+OKTA_ALLOWED_GROUPS_DEFAULT = None
 
 REGION_PASSWORD_OPTION_SUFFIX = '_password'
 
@@ -64,6 +79,8 @@ class BlessConfig(ConfigParser.RawConfigParser):
         self.aws_region = aws_region
         defaults = {CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,
                     CERTIFICATE_VALIDITY_AFTER_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,
+                    CERTIFICATE_BREAKGLASS_BEFORE_SEC_OPTION: CERTIFICATE_BREAKGLASS_SEC_DEFAULT,
+                    CERTIFICATE_BREAKGLASS_AFTER_SEC_OPTION: CERTIFICATE_BREAKGLASS_SEC_DEFAULT,
                     ENTROPY_MINIMUM_BITS_OPTION: ENTROPY_MINIMUM_BITS_DEFAULT,
                     RANDOM_SEED_BYTES_OPTION: RANDOM_SEED_BYTES_DEFAULT,
                     LOGGING_LEVEL_OPTION: LOGGING_LEVEL_DEFAULT,
@@ -71,7 +88,10 @@ class BlessConfig(ConfigParser.RawConfigParser):
                     KMSAUTH_SERVICE_ID_OPTION: KMSAUTH_SERVICE_ID_DEFAULT,
                     KMSAUTH_KEY_ID_OPTION: KMSAUTH_KEY_ID_DEFAULT,
                     KMSAUTH_USEKMSAUTH_OPTION: KMSAUTH_USEKMSAUTH_DEFAULT,
-                    CERTIFICATE_EXTENSIONS_OPTION: CERTIFICATE_EXTENSIONS_DEFAULT
+                    CERTIFICATE_EXTENSIONS_OPTION: CERTIFICATE_EXTENSIONS_DEFAULT,
+                    ENCRYPTED_OKTA_API_TOKEN_OPTION: ENCRYPTED_OKTA_API_TOKEN_DEFAULT,
+                    OKTA_BASE_URL_OPTION: OKTA_BASE_URL_DEFAULT,
+                    OKTA_ALLOWED_GROUPS_OPTION: OKTA_ALLOWED_GROUPS_DEFAULT
                     }
         ConfigParser.RawConfigParser.__init__(self, defaults=defaults)
         self.read(config_file)
@@ -81,6 +101,9 @@ class BlessConfig(ConfigParser.RawConfigParser):
 
         if not self.has_section(KMSAUTH_SECTION):
             self.add_section(KMSAUTH_SECTION)
+
+        if not self.has_section(OKTA_OPTIONS_SECTION):
+            self.add_section(OKTA_OPTIONS_SECTION)
 
         if not self.has_option(BLESS_CA_SECTION, self.aws_region + REGION_PASSWORD_OPTION_SUFFIX):
             raise ValueError("No Region Specific Password Provided.")

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -1,36 +1,65 @@
-# This section and its options are optional
 [Bless Options]
+# This section and its options are optional
+
 # Number of seconds +/- the issued time for the certificate to be valid
 certificate_validity_after_seconds = 120
 certificate_validity_before_seconds = 120
+
+# Number of seconds +/- the issued time for the breakglass certificate to be valid
+certificate_breakglass_validity_before_seconds = 60
+certificate_breakglass_validity_after_seconds = 60
+
+breakglass_user = example_username
+
+
 # Minimum number of bits in the system entropy pool before requiring an additional seeding step
 entropy_minimum_bits = 2048
+
 # Number of bytes of random to fetch from KMS to seed /dev/urandom
 random_seed_bytes = 256
+
 # Set the logging level
 logging_level = INFO
+
 # Comma separated list of the SSH Certificate extensions to include. Not specifying this uses the ssh-keygen defaults:
 # certificate_extensions = permit-X11-forwarding,permit-agent-forwarding,permit-port-forwarding,permit-pty,permit-user-rc
 
-# These values are all required to be modified for deployment
+
 [Bless CA]
+# These values are all required to be modified for deployment
+
 # AWS KMS key alias used to encrypt your private key password
 kms_key_id = <alias/key_name>
+
 # You must set an encrypted private key password for each AWS Region you deploy into
 # for each aws region specify a config option like '{}_password'.format(aws_region)
 us-east-1_password = <INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 us-west-2_password = <INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
+
 # Specify the file name of your SSH CA's Private Key in PEM format.
 ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>
 
-# This section is optional
+
 [KMS Auth]
+# This section is optional
+
 # Enable kmsauth, to ensure the certificate's username matches the AWS user
-# use_kmsauth = True
+use_kmsauth = True
 
 # One or multiple KMS keys, setup for kmsauth (see github.com/lyft/python-kmsauth)
-# kmsauth_key_id = arn:aws:kms:us-east-1:000000012345:key/eeff5544-6677-8899-9988-aaaabbbbcccc
+kmsauth_key_id = arn:aws:kms:us-east-1:000000012345:key/eeff5544-6677-8899-9988-aaaabbbbcccc
 
 # If using kmsauth, you need to set the kmsauth service name. Users need to set the 'to'
 # context to this same service name when they create a kmsauth token.
-# kmsauth_serviceid = bless-production
+kmsauth_serviceid = bless-production
+
+
+[Okta Options]
+
+encrypted_okta_api_token = atoken
+
+# If using okta as your user context and ssh certificate store, specify the API base url here
+okta_base_url = https://my.company.okta.com
+
+# Additionally, we can raise an alarm for users who do not belong to the below white list
+okta_allowed_groups = g1,g2,g3,g4


### PR DESCRIPTION
Extend bless config
    Breakglass groups
    Breakglass cert lifetime
    Define an Okta section header to clean it up

Extend bless functionalty
    On cert generation request we will now
        fetch groups from okta,
        compare against configured list
        alert if user is not in configured group white list (breakglass)
        generate a shorter certificate lifetime (breakglass)
        generate a certificate with a breakglass username